### PR TITLE
Update pubspec.yaml http requirements for flutter_google_places

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,8 @@ dependencies:
     sdk: flutter
   google_api_headers: ^1.3.0
   google_maps_webservice: ^0.0.20-nullsafety.5
-  http: ^0.13.4
+  #http: ^0.13.4
+  http: '>=0.13.4 <1.2.1'
   rxdart: ^0.27.5
 
 dev_dependencies:


### PR DESCRIPTION
the http requirement is set at 0.13.4 which is not compatible with other packages. I have changed it to include a wider cooverage.